### PR TITLE
feat: Add favorite contact screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:phone_bookr/models/contact_data.dart';
 import 'package:phone_bookr/screens/contacts_screen.dart';
+import 'package:phone_bookr/screens/favorite_contact_screen.dart';
 import 'package:provider/provider.dart';
-
-
 
 void main() {
   runApp(MyApp());
@@ -14,9 +13,35 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (context) => ContactData(),
-          child: MaterialApp(
+      child: MaterialApp(
         title: 'Flutter Demo',
-        home: ContactsScreen(),
+        home: DefaultTabController(
+          child: Scaffold(
+            appBar: AppBar(
+              title: Text("Contacts"),
+              bottom: TabBar(
+                isScrollable: true,
+                tabs: [
+                  Tab(
+                    icon: Icon(Icons.contact_phone),
+                    text: "Contacts",
+                  ),
+                  Tab(
+                    icon: Icon(Icons.star_rate),
+                    text: "Favorites",
+                  ),
+                ],
+              ),
+            ),
+            body: TabBarView(
+              children: [
+                ContactsScreen(),
+                FavoriteContactScreen(),
+              ],
+            ),
+          ),
+          length: 2,
+        ),
       ),
     );
   }

--- a/lib/models/contact_data.dart
+++ b/lib/models/contact_data.dart
@@ -66,12 +66,29 @@ class ContactData extends ChangeNotifier {
     ),
   ];
 
+  // List<Contact> _favoriteContacts = _contacts.where((Contact contact) =>contact.isFavorite == true);
+  List<Contact> _favoriteContacts = [];
+
   UnmodifiableListView<Contact> get contacts {
     return UnmodifiableListView(_contacts);
   }
 
+  updateFav() {
+    _favoriteContacts =
+        _contacts.where((Contact contact) => contact.isFavorite == true);
+    return _favoriteContacts;
+  }
+
+  UnmodifiableListView<Contact> get favoriteContacts {
+    return UnmodifiableListView(_favoriteContacts);
+  }
+
   int get contactCount {
     return _contacts.length;
+  }
+
+  int get favcontactCount {
+    return _favoriteContacts.length;
   }
 
   void addContact(String firstName, String lastName, String phoneNumber) {
@@ -89,8 +106,9 @@ class ContactData extends ChangeNotifier {
     notifyListeners();
   }
 
-   makeFavorite(Contact contact) {
+  makeFavorite(Contact contact) {
     contact.isFavorite = !contact.isFavorite;
+    _favoriteContacts.add(contact);
     notifyListeners();
   }
 }

--- a/lib/screens/FavSingleContact.dart
+++ b/lib/screens/FavSingleContact.dart
@@ -1,0 +1,1 @@
+import 'package:flutter/material.dart';

--- a/lib/screens/contacts_screen.dart
+++ b/lib/screens/contacts_screen.dart
@@ -21,57 +21,13 @@ class ContactsScreen extends StatelessWidget {
             ),
           );
         },
-        backgroundColor: Colors.amberAccent,
+        backgroundColor: Colors.blueAccent,
         child: Icon(Icons.add),
-        foregroundColor: Colors.black,
+        foregroundColor: Colors.white,
       ),
       body: Column(
         children: [
-          Container(
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.only(
-                bottomLeft: Radius.circular(30.0),
-                bottomRight: Radius.circular(30.0),
-              ),
-            ),
-            padding: EdgeInsets.only(
-              top: 60.0,
-              right: 20.0,
-              bottom: 30.0,
-              left: 20.0,
-            ),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                Text(
-                  "Contact List",
-                  style: TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 20.0,
-                  ),
-                ),
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    Icon(
-                      Icons.search,
-                      size: 30.0,
-                    ),
-                    CircleAvatar(
-                      child: Icon(
-                        Icons.apps,
-                        size: 30.0,
-                      ),
-                      radius: 20.0,
-                      backgroundColor: Color(0xff8F58FF),
-                    ),
-                  ],
-                )
-              ],
-            ),
-          ),
+          Container(),
           Expanded(
             child: Container(
               child: Container(

--- a/lib/screens/favorite_contact_screen.dart
+++ b/lib/screens/favorite_contact_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:phone_bookr/models/contact_data.dart';
+import 'package:phone_bookr/models/contact_model.dart';
+import 'package:phone_bookr/widgets/contact_tile.dart';
+import 'package:provider/provider.dart';
+import 'package:phone_bookr/screens/single_contact.dart';
+
+class FavoriteContactScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ContactData>(
+      builder: (context, contactData, child) {
+        List<Contact> favorite = contactData.contacts
+            .where((Contact contact) => contact.isFavorite == true)
+            .toList();
+        return Container(
+          color: Colors.redAccent,
+          child: ListView.separated(
+            separatorBuilder: (context, index) => Divider(
+              color: Colors.blue,
+              thickness: 2.0,
+            ),
+            itemCount: contactData.favcontactCount,
+            itemBuilder: (context, index) {
+              final contact = favorite[index];
+              return ContactTile(
+                firstName: contact.firstName,
+                lastName: contact.lastName,
+                phoneNumber: contact.phoneNumber,
+                contactIndex: index,
+                // onTap: () {
+                //   Navigator.push(context, MaterialPageRoute(builder: (context) {
+                //     return SingleContact(
+                //       contactIndex: index,
+                //     );
+                //   }));
+                // },
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/single_contact.dart
+++ b/lib/screens/single_contact.dart
@@ -7,8 +7,8 @@ import 'package:flutter/services.dart';
 
 class SingleContact extends StatelessWidget {
   SingleContact({@required this.contactIndex});
-
   final contactIndex;
+
   Widget build(BuildContext context) {
     double deviceHeight = MediaQuery.of(context).size.height;
     return Scaffold(

--- a/lib/widgets/contact_tile.dart
+++ b/lib/widgets/contact_tile.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:phone_bookr/screens/single_contact.dart';
 // import 'package:phone_bookr/test_single.dart';
 
 class ContactTile extends StatelessWidget {
@@ -47,11 +46,7 @@ class ContactTile extends StatelessWidget {
         ),
       ),
       onLongPress: deleteCallback,
-      onTap: () {
-        Navigator.push(context, MaterialPageRoute(builder: (context) {
-          return SingleContact(contactIndex: contactIndex);
-        }));
-      },
+      onTap:onTap,
     );
   }
 }

--- a/lib/widgets/contacts_list.dart
+++ b/lib/widgets/contacts_list.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:phone_bookr/models/contact_data.dart';
 import 'package:phone_bookr/widgets/contact_tile.dart';
 import 'package:provider/provider.dart';
+import 'package:phone_bookr/screens/single_contact.dart';
+
 
 class ContactsList extends StatelessWidget {
   @override
@@ -15,12 +17,16 @@ class ContactsList extends StatelessWidget {
           ),
           itemBuilder: (context, index) {
             final contact = contactData.contacts[index];
-            // print('contact favourite ${contact.isFavorite}');
             return ContactTile(
               firstName: contact.firstName,
               lastName: contact.lastName,
               phoneNumber: contact.phoneNumber,
               contactIndex: index,
+              onTap: () {
+                Navigator.push(context, MaterialPageRoute(builder: (context) {
+                  return SingleContact(contactIndex: index,);
+                }));
+              },
             );
           },
           itemCount: contactData.contactCount,


### PR DESCRIPTION
##  What does this PR do
Implemented favorite contact functionality.

##  Description of task to be completed
 * Add the logic that adds the selected contact to favorite list and attach it to the favorite icon
 * Create a screen that shows the favorite contacts
 * Modify the main screen view so user can navigate easily to the favorite contacts section

##  How should this manually be tested
* Clone the repository
* Open a terminal and run `git clone repo`
* cd into the project folder
* Run `flutter get`
* Select a contact, and click on the favorite icon
* Click on the favorite tab to see the contact added to the favorite list.

##  Screenshots (If appropriate)
![Screenshot_1614497208](https://user-images.githubusercontent.com/19408669/109410973-e9d86a00-799e-11eb-838a-eb68d3274836.png)
![Screenshot_1614497241](https://user-images.githubusercontent.com/19408669/109410975-eba22d80-799e-11eb-834b-a8c425ddf8de.png)


##  Questions (If any): 